### PR TITLE
Implement QUIC protocol - part1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,6 +76,8 @@
         "cinttypes": "cpp",
         "typeinfo": "cpp",
         "valarray": "cpp",
-        "variant": "cpp"
+        "variant": "cpp",
+        "csignal": "cpp",
+        "source_location": "cpp"
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,13 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
 endif()
 
 # set up library dependencies
+find_package(ada CONFIG REQUIRED)
 find_package(libuv CONFIG REQUIRED)
 find_package(spdlog CONFIG REQUIRED)
 find_package(unofficial-sodium CONFIG REQUIRED)
 
 # these do not correctly support CMake
+find_path(ADA_INCLUDE_DIR ada.h REQUIRED)
 find_path(SODIUM_INCLUDE_DIR sodium.h REQUIRED)
 
 # customize the builds of key networking components; WolfSSL is not 
@@ -59,9 +61,12 @@ add_library(
   sdk/client.cc
   sdk/model.cc
   sdk/serialization.cc
+  sdk/net/address.cc
+  sdk/net/protocol.cc
+  sdk/net/iggy.cc
 )
 target_compile_features(iggy PRIVATE cxx_std_17)
-target_include_directories(iggy PRIVATE ${SODIUM_INCLUDE_DIR} ${USOCKETS_INCLUDE_DIR})
+target_include_directories(iggy PRIVATE ${SODIUM_INCLUDE_DIR} ${ADA_INCLUDE_DIR})
 
 if (BUILD_TESTS)
   add_subdirectory(tests)

--- a/sdk/binary.h
+++ b/sdk/binary.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "serialization.h"
+
 namespace iggy {
 namespace serialization {
 /**
@@ -49,7 +51,7 @@ enum CommandCode {
  * @class BinaryWireFormat
  * @brief Simple binary serialization and deserialization for Iggy's protocol.   
  */
-class BinaryWireFormat : WireFormat {
+class BinaryWireFormat : iggy::serialization::WireFormat {
 public:
     BinaryWireFormat() = default;
 }

--- a/sdk/client.h
+++ b/sdk/client.h
@@ -4,33 +4,10 @@
 #include <stdexcept>
 #include <string>
 #include "model.h"
+#include "net/iggy.h"
+#include "net/transport.h"
 
 namespace iggy {
-namespace transport {
-
-/**
- * @enum Transport
- * @brief Available network transports for the Iggy server. Not all currently supported by the C++ client.
- */
-enum Transport {
-    /**
-     * @brief Modern networking protocol from Google built on top of UDP.
-     *
-     * @ref [Wikipedia](https://en.wikipedia.org/wiki/QUIC)
-     */
-    QUIC,
-
-    /**
-     * @brief Classic HTTP REST encoded as JSON. Not recommended for high performance applications.
-     */
-    HTTP,
-
-    /**
-     * @brief Binary protocol over TCP/IP. This is the default transport.
-     */
-    TCP
-};
-};  // namespace transport
 namespace client {
 
 /**
@@ -52,10 +29,6 @@ public:
     ~Credentials() { sodium_memzero(&password[0], password.size()); }
 };
 
-const unsigned short DEFAULT_HTTP_PORT = 3000;
-const unsigned short DEFAULT_TCP_PORT = 8090;
-const unsigned short DEFAULT_QUIC_PORT = 8080;
-
 /**
  * @struct Options
  * @brief A struct to hold various options.
@@ -73,12 +46,12 @@ struct Options {
     /**
      * @brief The port the Iggy server is listening on; default depends on transport. Defaults to the DEFAULT_TCP_PORT.
      */
-    unsigned short port = DEFAULT_TCP_PORT;
+    unsigned short port = iggy::net::DEFAULT_TCP_PORT;
 
     /**
      * @brief The network transport to use when connecting to the server. Defaults to TCP.
      */
-    iggy::transport::Transport transport = iggy::transport::Transport::TCP;
+    iggy::net::transport::Transport transport = iggy::net::transport::Transport::TCP;
 
     /**
      * @brief The user credentials to use when connecting to the server.

--- a/sdk/json.h
+++ b/sdk/json.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "serialization.h"
+
 namespace iggy {
 namespace serialization {
 
@@ -13,7 +15,7 @@ namespace json {
  * @class JsonWireFormat
  * @brief Binary serialization and deserialization for Iggy's protocol.   
  */
-class JsonWireFormat : WireFormat {
+class JsonWireFormat : iggy::serialization::WireFormat {
 public:
     JsonWireFormat() = default;
 }

--- a/sdk/net/address.cc
+++ b/sdk/net/address.cc
@@ -1,0 +1,34 @@
+#include "address.h"
+
+const iggy::net::protocol::ProtocolDefinition& iggy::net::address::LogicalAddress::getProtocolDefinition() const {
+    return this->protocolProvider->getProtocolDefinition(this->getProtocol());
+}
+
+iggy::net::address::LogicalAddress::LogicalAddress(const std::string& url, const iggy::net::protocol::ProtocolProvider* protocolProvider) {
+    auto parse_result = ada::parse<ada::url>(url);
+    if (!parse_result) {
+        throw std::invalid_argument("Invalid URL: " + url);
+    }
+    auto value = parse_result.value();
+    auto protocol = value.get_protocol();
+    if (!protocolProvider->isSupported(protocol)) {
+        throw std::invalid_argument("Unsupported protocol: " + protocol);
+    }
+    this->url = value;
+    this->protocolProvider = protocolProvider;
+}
+
+const unsigned short iggy::net::address::LogicalAddress::getPort() const {
+    if (url.get_port().empty()) {
+        return this->getProtocolDefinition().getDefaultPort();
+    } else {
+        int port = std::stoi(url.get_port());
+
+        // this should not happen if ada::parse is working correctly
+        if (port < 0 || port > 65535) {
+            throw std::out_of_range("Port number out of range");
+        }
+
+        return port;
+    }
+}

--- a/sdk/net/address.h
+++ b/sdk/net/address.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <ada.h>
+#include <vector>
+#include "protocol.h"
+#include "transport.h"
+
+namespace iggy {
+namespace net {
+namespace address {
+
+/***
+ * @brief Logical address used in configuration and API to specify desired transport in a compact way, e.g. iggy:quic://localhost:8080.
+ */
+class LogicalAddress {
+private:
+    ada::url url;
+    const iggy::net::protocol::ProtocolProvider* protocolProvider;
+
+    const iggy::net::protocol::ProtocolDefinition& getProtocolDefinition() const;
+public:
+    /**
+     * @brief Construct a logical address from a URL.
+     * @param url URL to parse.
+     * @param protocolProvider Context object providing supported protocols and default ports.
+     * @throws std::invalid_argument if the URL is invalid or the protocol is unknown.
+     */
+    LogicalAddress(const std::string& url, const iggy::net::protocol::ProtocolProvider* protocolProvider);
+
+    /**
+     * @brief Gets the protocol; you have a guarantee that it will be one of the supported protocols from ProtocolProvider.
+     */
+    const std::string getProtocol() const noexcept { return url.get_protocol(); }
+
+    /**
+     * @brief Gets the hostname to connect to or raw IP address.
+     */
+    const std::string getHost() const noexcept { return url.get_hostname(); }
+
+    /**
+     * @brief Gets the port to connect to; protocol default port will be substituted if not specified. 
+     */
+    const unsigned short getPort() const;
+};
+}; // namespace address
+}; // namespace net
+}; // namespace iggy

--- a/sdk/net/iggy.cc
+++ b/sdk/net/iggy.cc
@@ -1,0 +1,25 @@
+#include "iggy.h"
+
+iggy::net::IggyProtocolProvider::IggyProtocolProvider() {
+    for (const auto& protocol : this->supportedProtocols) {
+        this->supportedProtocolLookup[protocol.getName()] = protocol;
+    }
+}
+
+const std::vector<iggy::net::protocol::ProtocolDefinition>& iggy::net::IggyProtocolProvider::getSupportedProtocols() const {
+    return this->supportedProtocols;
+}
+
+const iggy::net::protocol::ProtocolDefinition& iggy::net::IggyProtocolProvider::getProtocolDefinition(const std::string& protocol) const {
+    auto normalizedName = iggy::net::protocol::normalizeProtocolName(protocol);
+    auto it = this->supportedProtocolLookup.find(normalizedName);
+    if (it != this->supportedProtocolLookup.end()) {
+        return it->second;
+    } else {
+        throw std::invalid_argument("Unsupported protocol: " + protocol);
+    }
+}
+
+const bool iggy::net::IggyProtocolProvider::isSupported(const std::string& protocol) const {
+    return this->supportedProtocolLookup.count(iggy::net::protocol::normalizeProtocolName(protocol)) > 0;
+}

--- a/sdk/net/iggy.h
+++ b/sdk/net/iggy.h
@@ -1,0 +1,45 @@
+#pragma once
+#include <map>
+#include <vector>
+#include "address.h"
+
+namespace iggy {
+namespace net {
+
+const unsigned short DEFAULT_HTTP_PORT = 3000;
+const unsigned short DEFAULT_TCP_PORT = 8090;
+const unsigned short DEFAULT_QUIC_PORT = 8080;
+
+const std::string QUIC_PROTOCOL = "iggy:quic";
+const std::string TCP_PROTOCOL = "iggy:tcp";
+const std::string TCP_TLS_PROTOCOL = "iggy:tcp+tls";
+const std::string HTTP_PROTOCOL = "iggy:http";
+const std::string HTTP_TLS_PROTOCOL = "iggy:http+tls";
+
+using iggy::net::protocol::MessageEncoding;
+using iggy::net::protocol::ProtocolDefinition;
+
+/**
+ * @brief Provider that declares support and offers defaults for all Iggy C++ supported protocols.
+ *
+ * At this time we support iggy:quic, iggy:tcp (binary messaging) and iggy:http (with JSON messaging).
+ */
+class IggyProtocolProvider : iggy::net::protocol::ProtocolProvider {
+private:
+    std::vector<ProtocolDefinition> supportedProtocols = {
+        ProtocolDefinition(QUIC_PROTOCOL, DEFAULT_QUIC_PORT, iggy::net::transport::QUIC, true, MessageEncoding::BINARY),
+        ProtocolDefinition(TCP_PROTOCOL, DEFAULT_TCP_PORT, iggy::net::transport::TCP, false, MessageEncoding::BINARY),
+        ProtocolDefinition(TCP_TLS_PROTOCOL, DEFAULT_TCP_PORT, iggy::net::transport::TCP, true, MessageEncoding::BINARY),
+        ProtocolDefinition(HTTP_PROTOCOL, DEFAULT_HTTP_PORT, iggy::net::transport::HTTP, false, MessageEncoding::TEXT),
+        ProtocolDefinition(HTTP_TLS_PROTOCOL, DEFAULT_HTTP_PORT, iggy::net::transport::HTTP, true, MessageEncoding::TEXT)};
+    std::map<std::string, ProtocolDefinition> supportedProtocolLookup;
+
+public:
+    IggyProtocolProvider();
+    const std::vector<ProtocolDefinition>& getSupportedProtocols() const override;
+    const ProtocolDefinition& getProtocolDefinition(const std::string& protocol) const override;
+    const bool isSupported(const std::string& protocol) const override;
+};
+
+};  // namespace net
+};  // namespace iggy

--- a/sdk/net/protocol.cc
+++ b/sdk/net/protocol.cc
@@ -1,0 +1,24 @@
+#include "address.h"
+#include "protocol.h"
+
+iggy::net::address::LogicalAddress iggy::net::protocol::ProtocolProvider::createAddress(const std::string& url) const {
+    return iggy::net::address::LogicalAddress(url, this);
+}
+
+const std::string iggy::net::protocol::normalizeProtocolName(const std::string& protocol) {
+    // convert to lowercase
+    std::string lowerStr = protocol;
+    std::transform(lowerStr.begin(), lowerStr.end(), lowerStr.begin(), ::tolower);
+
+    // trim whitespace from the start
+    auto start = lowerStr.find_first_not_of(" \t\n\r\f\v");
+    if (start == std::string::npos) {
+        throw std::invalid_argument("Protocol name cannot be empty");
+    }
+
+    // trim whitespace from the end
+    auto end = lowerStr.find_last_not_of(" \t\n\r\f\v");
+
+    // return the trimmed, lowercase string
+    return lowerStr.substr(start, end - start + 1);
+}

--- a/sdk/net/protocol.h
+++ b/sdk/net/protocol.h
@@ -49,10 +49,29 @@ public:
     ProtocolDefinition() = default;
     ProtocolDefinition(const ProtocolDefinition& other) = default;
 
+    /**
+     * @brief Get the protocol name, e.g. iggy:tcp+tls.
+     */
     const std::string& getName() const { return name; }
+
+    /**
+     * @brief Gets the default port for the protocol, e.g. 443 for https.
+     */
     unsigned short getDefaultPort() const { return defaultPort; }
+
+    /**
+     * @brief Gets the transport for the protocol, e.g. iggy::net::transport::Transport::TCP.
+     */
     iggy::net::transport::Transport getTransport() const { return transport; };
+
+    /**
+     * @brief Tests whether the protocol supports TLS; insecure and TLS protocols should be separate. 
+     */
     bool isTlsSupported() const { return tlsSupported; }
+
+    /**
+     * @brief Gets the default message encoding used by the protocol, e.g. MessageEncoding::TEXT for JSON.
+     */
     MessageEncoding getMessageEncoding() const { return messageEncoding; }
 };
 
@@ -66,6 +85,7 @@ public:
 
     /**
      * @brief Factory method to create a logical address from a URL.
+     * @param url The URL to parse in the context of this provider and its defaults.
      */
     iggy::net::address::LogicalAddress createAddress(const std::string& url) const;
 
@@ -77,12 +97,13 @@ public:
     /**
      * @brief Given a normalized protocol name returns the definition with protocol metadata.
      */
-    virtual const ProtocolDefinition& getProtocolDefinition(const std::string& protocol) const;
+    virtual const ProtocolDefinition& getProtocolDefinition(const std::string& protocol) const = 0;
 
     /**
      * @brief Tests whether the given protocol is supported by this provider.
+     * @param protocol The protocol name to test.
      */
-    virtual const bool isSupported(const std::string& protocol) const;
+    virtual const bool isSupported(const std::string& protocol) const = 0;
 };
 
 };  // namespace protocol

--- a/sdk/net/protocol.h
+++ b/sdk/net/protocol.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "transport.h"
+
+namespace iggy {
+namespace net {
+namespace address {
+class LogicalAddress;
+};
+
+namespace protocol {
+
+/**
+ * @brief Enumerates the supported message encodings.
+ */
+enum MessageEncoding { BINARY = 0, TEXT = 1 };
+
+/**
+ * @brief Normalizes the protocol name to a canonical form.
+ */
+const std::string normalizeProtocolName(const std::string& protocol);
+
+
+/**
+ * @brief Metadata about a protocol including its default port, transport, TLS support and message encoding.
+ */
+class ProtocolDefinition {
+private:
+    std::string name;
+    unsigned short defaultPort;
+    iggy::net::transport::Transport transport;
+    bool tlsSupported;
+    MessageEncoding messageEncoding;
+
+public:
+    ProtocolDefinition(const std::string& name,
+                       unsigned short defaultPort,
+                       iggy::net::transport::Transport transport,
+                       bool tlsSupported,
+                       MessageEncoding messageEncoding)
+        : name(iggy::net::protocol::normalizeProtocolName(name))
+        , defaultPort(defaultPort)
+        , transport(transport)
+        , tlsSupported(tlsSupported)
+        , messageEncoding(messageEncoding) {}
+
+    ProtocolDefinition() = default;
+    ProtocolDefinition(const ProtocolDefinition& other) = default;
+
+    const std::string& getName() const { return name; }
+    unsigned short getDefaultPort() const { return defaultPort; }
+    iggy::net::transport::Transport getTransport() const { return transport; };
+    bool isTlsSupported() const { return tlsSupported; }
+    MessageEncoding getMessageEncoding() const { return messageEncoding; }
+};
+
+/**
+ * @brief Interface to plug in library-specific information on supported protocols.
+ */
+class ProtocolProvider {
+public:
+    ProtocolProvider() = default;
+    virtual ~ProtocolProvider() = default;
+
+    /**
+     * @brief Factory method to create a logical address from a URL.
+     */
+    iggy::net::address::LogicalAddress createAddress(const std::string& url) const;
+
+    /**
+     * @brief Enumerates all the supported protocols in the provider.
+     */
+    virtual const std::vector<ProtocolDefinition>& getSupportedProtocols() const = 0;
+
+    /**
+     * @brief Given a normalized protocol name returns the definition with protocol metadata.
+     */
+    virtual const ProtocolDefinition& getProtocolDefinition(const std::string& protocol) const;
+
+    /**
+     * @brief Tests whether the given protocol is supported by this provider.
+     */
+    virtual const bool isSupported(const std::string& protocol) const;
+};
+
+};  // namespace protocol
+};  // namespace net
+};  // namespace iggy

--- a/sdk/net/quic/address.h
+++ b/sdk/net/quic/address.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/sdk/net/quic/conn.h
+++ b/sdk/net/quic/conn.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/sdk/net/quic/stream.h
+++ b/sdk/net/quic/stream.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/sdk/net/quic/tls.h
+++ b/sdk/net/quic/tls.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/sdk/net/transport.h
+++ b/sdk/net/transport.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace iggy {
+namespace net {
+namespace transport {
+
+/**
+ * @brief Available network transports in the client library.
+ */
+enum Transport {
+    /**
+     * @brief Modern networking protocol from Google built on top of UDP.
+     *
+     * @ref [Wikipedia](https://en.wikipedia.org/wiki/QUIC)
+     */
+    QUIC,
+
+    /**
+     * @brief Classic HTTP REST encoded as JSON. Not recommended for high performance applications.
+     */
+    HTTP,
+
+    /**
+     * @brief Binary protocol over TCP/IP.
+     */
+    TCP
+};
+    
+};  // namespace net
+};  // namespace transport
+};  // namespace iggy

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 if(BUILD_TESTS)
-  find_package(catch2 CONFIG REQUIRED)
+  find_package(Catch2 CONFIG REQUIRED)
   find_package(reproc++ CONFIG REQUIRED)
 
   add_executable(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,19 +1,7 @@
 
-# set up GoogleTest
 if(BUILD_TESTS)
-  include(FetchContent)
-  FetchContent_Declare(
-    googletest
-    URL https://github.com/google/googletest/archive/dddb219c3eb96d7f9200f09b0a381f016e6b4562.zip
-  )
-  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-  FetchContent_MakeAvailable(googletest)
-
-  # for E2E tests, controlling Docker containers
+  find_package(catch2 CONFIG REQUIRED)
   find_package(reproc++ CONFIG REQUIRED)
-
-  # set up GoogleTest
-  enable_testing()
 
   add_executable(
     iggy_cpp_test
@@ -24,7 +12,8 @@ if(BUILD_TESTS)
     iggy_cpp_test
 
     iggy
-    GTest::gtest_main
+    Catch2::Catch2
+    Catch2::Catch2WithMain
     libuv::uv_a
     reproc++
     unofficial-sodium::sodium
@@ -42,12 +31,10 @@ if(BUILD_TESTS)
     PRIVATE
 
     iggy
-    GTest::gtest_main
+    Catch2::Catch2
+    Catch2::Catch2WithMain
     libuv::uv_a
     reproc++
     unofficial-sodium::sodium
   )
-
-  include(GoogleTest)
-  gtest_discover_tests(iggy_cpp_test)
 endif()

--- a/tests/e2e_testutils.cc
+++ b/tests/e2e_testutils.cc
@@ -1,9 +1,11 @@
 #include "e2e_testutils.h"
 #include <chrono>
 #include <stdexcept>
+#include <string>
 #include <thread>
+#include <vector>
 
-void DockerTest::SetUp() {
+IggyRunner::IggyRunner() {
     // start the Docker process with stdout redirected to parent process
     std::vector<std::string> arguments = {"docker", "run", "-d", "--name", "iggy_test", "iggyrs/iggy:latest"};
     reproc::options options;
@@ -17,7 +19,7 @@ void DockerTest::SetUp() {
     std::this_thread::sleep_for(std::chrono::seconds(5));
 }
 
-void DockerTest::TearDown() {
+IggyRunner::~IggyRunner() {
     // stop the Docker process
     process.stop(reproc::stop_actions{{reproc::stop::terminate, reproc::milliseconds(5000)},
                                       {reproc::stop::kill, reproc::milliseconds(2000)},

--- a/tests/e2e_testutils.h
+++ b/tests/e2e_testutils.h
@@ -1,20 +1,18 @@
 #pragma once
-#include <gtest/gtest.h>
 #include <reproc++/reproc.hpp>
 
 /**
- * @class DockerTest
- * @brief GoogleTest fixture that starts and stops a Docker container for each test.
+ * @brief Test fixture that starts and stops a Docker container for each test.
  *
  * This test fixture is meant for use in end-to-end (E2E) tests for the Iggy C++ client.
  * It will start up the latest Iggy server inside a Docker container, allow you to
  * interact with it, then stop and remove the container in the TearDown() method.
  */
-class DockerTest : public ::testing::Test {
-protected:
+class IggyRunner {
+private:
     reproc::process process;
 
-    void SetUp() override;
-
-    void TearDown() override;
+public:
+    IggyRunner();
+    ~IggyRunner();
 };

--- a/tests/model_test.cc
+++ b/tests/model_test.cc
@@ -1,11 +1,8 @@
-#include <gtest/gtest.h>
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
 #include "../sdk/model.h"
 
-TEST(ModelTest, DefaultConstructor) {
-    // Create a Message object using the default constructor
+TEST_CASE("simple test for model objects", "[model]") {
     iggy::model::system::Stats stats;
-
-    // Perform assertions to verify the expected behavior
-    // For example, you can check if the message object is not null
-    ASSERT_NE(nullptr, &stats);
+    REQUIRE(&stats != nullptr);
 }

--- a/tests/ping_cmd_test.cc
+++ b/tests/ping_cmd_test.cc
@@ -1,7 +1,11 @@
+#include <catch.hpp>
 #include "e2e_testutils.h"
 #include "../sdk/client.h"
 
-TEST_F(DockerTest, BinaryPing) {
+TEST_CASE("E2E test for ping command", "[ping]") {
+    // Start the Docker container; shuts down when this object goes out of scope
+    IggyRunner runner;
+
     // Create a client object with all defaults
     iggy::client::Options options;
     iggy::client::Client client(options);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,6 @@
 {
   "dependencies": [
+    "ada-url",
     "icu",
     "libsodium",
     "libuv",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "dependencies": [
     "ada-url",
+    "catch2",
     "icu",
     "libsodium",
     "libuv",


### PR DESCRIPTION
Sets up initial build dependencies and class hierarchy for implementing QUIC with ngtcp2. As part of this, also ports over the unit test mechanism from GoogleTest to [Catch2](https://github.com/catchorg/Catch2).

Starts #23 and completes #22.
